### PR TITLE
Change /sync API to allow multiple sync methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Next, you'll need to set a few environment variables:
 | `MACHINE_USER_EMAIL` | **Required**. The Git email address of your machine user.
 | `MACHINE_USER_NAME` | **Required**. The Git author name of your machine user.
 
-On your private repository, set a webhook to point to the `/sync?squash` endpoint.
-Pass in one more parameter, `dest_repo`, the name of the public repository to update. It might look like `http://repository-sync.someserver.com/sync?squash&dest_repo=ourorg/public`. Don't forget to fill out the **Secret** field with your secret token!
+On your private repository, set a webhook to point to the `/sync?sync_method=squash` endpoint.
+Pass in one more parameter, `dest_repo`, the name of the public repository to update. It might look like `http://repository-sync.someserver.com/sync?sync_method=squash&dest_repo=ourorg/public`. Don't forget to fill out the **Secret** field with your secret token!
 
-On your public repository, set a webhook to point to the `/sync` endpoint.
+On your public repository, set a webhook to point to the `/sync?sync_method=merge` endpoint.
 Pass in just one parameter, `dest_repo`, the name of the private repository to update. It might look like `http://repository-sync.someserver.com/sync?dest_repo=ourorg/private`. Don't forget to fill out the **Secret** field with your secret token!
 
-You'll notice these two endpoints are practically the same. They are! The only difference is
-that, when hitting an endpoint with the `squash` path parameter, this tool will perform a `--squash merge` to hide the commit history.
+You'll notice these two endpoints are practically the same. They are! The only difference is the value of the `sync_method` parameter. When hitting an endpoint with the `sync_method=squash` path parameter, this tool will perform a `--squash merge` to hide the commit history.
+
+There is a third, *highly experimental*, sync method. `sync_method=replace_contents` will completely remove the public repository contents and replace them with the contents of the private repository. Its use is not recommended.
 
 ### Between a GitHub.com repository and a GitHub Enterprise repository
 
@@ -44,7 +45,7 @@ Next, you'll need to set a few environment variables:
 | `MACHINE_USER_NAME` | **Required**. The Git author name of your machine user.
 
 On your private repository, set a webhook to point to the `/sync` endpoint.
-Pass in just one parameter, `dest_repo`, the name of the public repository to update. It might look like `http://repository-sync.someserver.com/sync?squash&dest_repo=ourorg/public`. Don't forget to fill out the **Secret** field with your secret token!
+Pass in just one parameter, `dest_repo`, the name of the public repository to update. It might look like `http://repository-sync.someserver.com/sync?sync_method=squash&dest_repo=ourorg/public`. Don't forget to fill out the **Secret** field with your secret token!
 
 On your public repository, set a webhook to point to the `/sync` endpoint.
 Pass in two parameters:

--- a/Rakefile
+++ b/Rakefile
@@ -22,11 +22,12 @@ task 'jobs:work' => 'resque:work'
 namespace :deploy do
   desc 'Deploy the app'
   task :production do
+    branch = ENV['BRANCH'] || 'master'
     app = 'github-repository-sync'
     remote = "git@heroku.com:#{app}.git"
 
     system "heroku maintenance:on --app #{app}"
-    system "git push #{remote} master"
+    system "git push --force #{remote} #{branch}:master"
     system "heroku run rake db:migrate --app #{app}"
     system "heroku maintenance:off --app #{app}"
   end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -21,6 +21,8 @@ class RepositorySync < Sinatra::Base
     configure_redis
   end
 
+  SUPPORTED_SYNC_METHODS = ['squash', 'merge', 'replace_contents']
+
   get '/' do
     'You\'ll want to make a POST to /sync. Check the documentation for more info.'
   end
@@ -44,13 +46,15 @@ class RepositorySync < Sinatra::Base
     @payload = JSON.parse(payload_body)
     halt 202, "Payload was not for master, was for #{@payload['ref']}, aborting." unless master_branch?(@payload)
 
-    @squash = params[:squash]
+    @sync_method = params[:sync_method] || "merge"
+    @sync_method = "squash" if params[:squash]
+    halt 400, "sync_method #{@sync_method} not supported" unless SUPPORTED_SYNC_METHODS.include?(@sync_method)
 
     # keep some important vars
     process_payload(@payload)
     @destination_hostname = params[:destination_hostname] || 'github.com'
 
-    Resque.enqueue(CloneJob, @after_sha, @destination_hostname, @destination_repo, @originating_hostname, @originating_repo, @squash)
+    Resque.enqueue(CloneJob, @after_sha, @destination_hostname, @destination_repo, @originating_hostname, @originating_repo, @sync_method)
   end
 
   helpers Helpers

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -46,6 +46,11 @@ class RepositorySync < Sinatra::Base
     @payload = JSON.parse(payload_body)
     halt 202, "Payload was not for master, was for #{@payload['ref']}, aborting." unless master_branch?(@payload)
 
+    # Support ?squash parameter for backwards compatibility.
+    if params[:squash] && params[:sync_method].nil?
+      params[:sync_method] = "squash"
+    end
+
     @sync_method = params[:sync_method] || "merge"
     halt 400, "sync_method #{@sync_method} not supported" unless SUPPORTED_SYNC_METHODS.include?(@sync_method)
 

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -47,7 +47,6 @@ class RepositorySync < Sinatra::Base
     halt 202, "Payload was not for master, was for #{@payload['ref']}, aborting." unless master_branch?(@payload)
 
     @sync_method = params[:sync_method] || "merge"
-    @sync_method = "squash" if params[:squash]
     halt 400, "sync_method #{@sync_method} not supported" unless SUPPORTED_SYNC_METHODS.include?(@sync_method)
 
     # keep some important vars

--- a/lib/clone_job.rb
+++ b/lib/clone_job.rb
@@ -5,7 +5,7 @@ require_relative "cloner"
 class CloneJob
   @queue = :default
 
-  def self.perform(after_sha, destination_hostname, destination_repo, originating_hostname, originating_repo, squash)
+  def self.perform(after_sha, destination_hostname, destination_repo, originating_hostname, originating_repo, sync_method)
 
     cloner = Cloner.new({
       :after_sha            => after_sha,
@@ -13,7 +13,7 @@ class CloneJob
       :destination_repo     => destination_repo,
       :originating_hostname => originating_hostname,
       :originating_repo     => originating_repo,
-      :squash               => squash
+      :sync_method          => sync_method
     })
 
     cloner.clone

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -7,6 +7,7 @@ class Cloner
     :tmpdir               => nil,
     :after_sha            => nil,
     :squash               => nil,
+    :sync_method          => :merge,
     :destination_hostname => GITHUB_DOMAIN,
     :destination_repo     => nil,
     :originating_hostname => GITHUB_DOMAIN,

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -217,10 +217,8 @@ class Cloner
 
   def replace_contents
     logger.info "Committing contents of #{originating_repo}/master into #{branch_name} directly..."
-    run_command('git', 'rm', '-r', '*')
-    run_command('git', 'checkout', "#{remote_name}/master", '--', "*")
-    run_command('git', 'add', '-A', '.')
-    git.commit(commit_message)
+    commit_id = run_command('git', 'commit-tree', "#{remote_name}/master^{tree}", '-p', 'HEAD', '-m', commit_message)
+    run_command('git', 'update-ref', 'HEAD', commit_id.chomp)
   end
 
   def push

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -215,6 +215,9 @@ class Cloner
     git.commit(commit_message)
   end
 
+  # Using HEAD here is likely the best thing since HEAD will be a pointer to
+  # the head of the branch we checked out earlier and is likely more reliable
+  # than manually trying to use "refs/heads/#{branch_name}"
   def replace_contents
     logger.info "Committing contents of #{originating_repo}/master into #{branch_name} directly..."
     commit_id = run_command('git', 'commit-tree', "#{remote_name}/master^{tree}", '-p', 'HEAD', '-m', commit_message)

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -218,7 +218,7 @@ class Cloner
   def replace_contents
     logger.info "Committing contents of #{originating_repo}/master into #{branch_name} directly..."
     run_command('git', 'rm', '-r', '*')
-    run_command('git', 'checkout', "#{originating_repo}/master", '--', "'*'")
+    run_command('git', 'checkout', "#{remote_name}/master", '--', "*")
     run_command('git', 'add', '-A', '.')
     git.commit(commit_message)
   end

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -6,8 +6,7 @@ class Cloner
   DEFAULTS = {
     :tmpdir               => nil,
     :after_sha            => nil,
-    :squash               => nil,
-    :sync_method          => :merge,
+    :sync_method          => "merge",
     :destination_hostname => GITHUB_DOMAIN,
     :destination_repo     => nil,
     :originating_hostname => GITHUB_DOMAIN,
@@ -16,8 +15,7 @@ class Cloner
   }
 
   attr_accessor :tmpdir, :after_sha, :destination_hostname, :destination_repo
-  attr_accessor :originating_hostname, :originating_repo, :squash
-  alias_method :squash?, :squash
+  attr_accessor :originating_hostname, :originating_repo, :sync_method
 
   def initialize(options)
     logger.level = Logger::WARN if ENV['RACK_ENV'] == 'test'

--- a/spec/accepting_parameters_spec.rb
+++ b/spec/accepting_parameters_spec.rb
@@ -25,6 +25,13 @@ describe 'endpoints' do
       expect(last_response.body).to eql('Missing `dest_repo` argument')
     end
 
+    it 'does nothing without the right params' do
+      expect(app).to_not receive(:process_payload)
+      post '/sync?sync_method=forge_from_cosmic_oneness&dest_repo=gjtorikian/fake', incoming
+      expect(last_response.status).to eql(400)
+      expect(last_response.body).to eql('sync_method forge_from_cosmic_oneness not supported')
+    end
+
     it 'does nothing if payload is not for master' do
       expect(app).to_not receive(:process_payload)
       post '/sync?dest_repo=gjtorikian/fake', non_master_payload

--- a/spec/cloner_spec.rb
+++ b/spec/cloner_spec.rb
@@ -179,12 +179,12 @@ describe 'Cloner' do
 
   it "merges the changes" do
     cloner.instance_variable_set("@originating_url_with_token", fixture_path("/gjtorikian/originating_repo"))
-    cloner.squash = false
+    cloner.sync_method = "merge"
     cloner.git
     cloner.add_remote
     cloner.fetch
     commits = cloner.git.log.count
-    output = cloner.merge
+    output = cloner.apply_sync_method
     expect(output).to match(/1 file changed, 1 insertion/)
     expect(output).to match(/create mode 100644 file2.md/)
     expect(cloner.git.log.count).to eql(commits + 2)
@@ -192,12 +192,12 @@ describe 'Cloner' do
 
   it "squashes the changes when public" do
     cloner.instance_variable_set("@originating_url_with_token", fixture_path("/gjtorikian/originating_repo"))
-    cloner.squash = true
+    cloner.sync_method = "squash"
     cloner.git
     cloner.add_remote
     cloner.fetch
     commits = cloner.git.log.count
-    output = cloner.merge
+    output = cloner.apply_sync_method
     expect(output).to match(/1 file changed, 1 insertion/)
     expect(output).to match(/create mode 100644 file2.md/)
     expect(cloner.git.log.count).to eql(commits + 1) # Ensure the squash
@@ -220,7 +220,7 @@ describe 'Cloner' do
       cloner.git
       cloner.add_remote
       cloner.fetch
-      cloner.merge
+      cloner.apply_sync_method
       cloner.create_pull_request
     end
 
@@ -244,7 +244,7 @@ describe 'Cloner' do
       cloner.git
       cloner.add_remote
       cloner.fetch
-      cloner.merge
+      cloner.apply_sync_method
       cloner.create_pull_request
     end
     expect(stub).to have_been_requested

--- a/spec/cloner_spec.rb
+++ b/spec/cloner_spec.rb
@@ -211,9 +211,7 @@ describe 'Cloner' do
     cloner.fetch
     commits = cloner.git.log.count
     output = cloner.apply_sync_method
-    expect(output).to match(/1 file changed, 1 insertion/)
-    expect(output).to match(/create mode 100644 file2.md/)
-    # expect(somehow to test this as distinct from a squash)
+    expect(output).to eql("")
   end
 
   it "creates a pull request" do


### PR DESCRIPTION
:warning: WIP do not merge :construction: 

Rather than create a plethora of `?squash ?contents_only ?whateverelse`, what if we replaced `?squash` with `?sync_method=squash`?

The existing `?squash` parameter could be deprecated but accepted for now. This would be handy for adding a contents only sync that completely ignores the incoming history.