### PR TITLE
Use Bad Request error code instead of server error.

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -32,14 +32,14 @@ class RepositorySync < Sinatra::Base
     # ensure there's a payload
     request.body.rewind
     payload_body = request.body.read.to_s
-    halt 500, 'Missing body payload!' if payload_body.nil? || payload_body.empty?
+    halt 400, 'Missing body payload!' if payload_body.nil? || payload_body.empty?
 
     # ensure signature is correct
     github_signature = request.env['HTTP_X_HUB_SIGNATURE']
-    halt 500, 'Signatures didn\'t match!' unless signatures_match?(payload_body, github_signature)
+    halt 400, 'Signatures didn\'t match!' unless signatures_match?(payload_body, github_signature)
 
     @destination_repo = params[:dest_repo]
-    halt 500, 'Missing `dest_repo` argument' if @destination_repo.nil?
+    halt 400, 'Missing `dest_repo` argument' if @destination_repo.nil?
 
     @payload = JSON.parse(payload_body)
     halt 202, "Payload was not for master, was for #{@payload['ref']}, aborting." unless master_branch?(@payload)

--- a/spec/accepting_parameters_spec.rb
+++ b/spec/accepting_parameters_spec.rb
@@ -14,14 +14,14 @@ describe 'endpoints' do
     it 'does nothing without a body' do
       expect(app).to_not receive(:process_payload)
       post '/sync'
-      expect(last_response.status).to eql(500)
+      expect(last_response.status).to eql(400)
       expect(last_response.body).to eql('Missing body payload!')
     end
 
     it 'does nothing without the right params' do
       expect(app).to_not receive(:process_payload)
       post '/sync', incoming
-      expect(last_response.status).to eql(500)
+      expect(last_response.status).to eql(400)
       expect(last_response.body).to eql('Missing `dest_repo` argument')
     end
 


### PR DESCRIPTION
This might be pedantic but since all of these errors come from invalid request data, wouldn't 400 be a better indicator that this is the requester's fault and not repository_sync's?