### PR TITLE
Bump Git and Ruby buildpack versions.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/heroku/heroku-buildpack-ruby#v134
+https://github.com/heroku/heroku-buildpack-ruby#v138
 https://github.com/abhishekmunie/heroku-buildpack-git#9f9df99

--- a/_git.cfg
+++ b/_git.cfg
@@ -1,1 +1,1 @@
-git_version="2.3.5"
+git_version="2.5.0"


### PR DESCRIPTION
We're getting crashes related to linking errors with Git and libcrypto.

Hopefully bumping and rebuilding will resolve these.

Testing this out in a branch deploy now.