### PR TITLE
Fix 'I'm so sorry' GIFs not displaying

### DIFF
--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -177,7 +177,7 @@ class Cloner
     body << command_output
     body << "\n```\n"
     body << "You'll have to resolve this problem manually, I'm afraid.\n"
-    body << "![I'm so sorry](http://media.giphy.com/media/NxKcqJI6MdIgo/giphy.gif)"
+    body << "![I'm so sorry](https://media.giphy.com/media/NxKcqJI6MdIgo/giphy.gif)"
     body << "\n\n /cc #{committers.join(' ')}" unless committers.nil?
     client.create_issue originating_repo, 'Merge conflict detected', body
   end

--- a/spec/cloner_spec.rb
+++ b/spec/cloner_spec.rb
@@ -151,7 +151,7 @@ describe 'Cloner' do
 
   it "reports errors" do
     stub = stub_request(:post, "https://api.github.com/repos/gjtorikian/originating_repo/issues").
-    with(:body => "{\"labels\":[],\"title\":\"Merge conflict detected\",\"body\":\"Hey, I'm really sorry about this, but there was a merge conflict when I tried to auto-sync the last time, from :\\n\\n```\\nfoo\\nMerge error\\nbar\\n```\\nYou'll have to resolve this problem manually, I'm afraid.\\n![I'm so sorry](http://media.giphy.com/media/NxKcqJI6MdIgo/giphy.gif)\"}").
+    with(:body => "{\"labels\":[],\"title\":\"Merge conflict detected\",\"body\":\"Hey, I'm really sorry about this, but there was a merge conflict when I tried to auto-sync the last time, from :\\n\\n```\\nfoo\\nMerge error\\nbar\\n```\\nYou'll have to resolve this problem manually, I'm afraid.\\n![I'm so sorry](https://media.giphy.com/media/NxKcqJI6MdIgo/giphy.gif)\"}").
     to_return(:status => 204)
 
     output = "foo\nMerge error\nbar"


### PR DESCRIPTION
When there is a merge conflict, an issue gets created.
That issue has an animated gif (cool!). But it does not display:
![image](https://user-images.githubusercontent.com/5385290/34201357-87fb0822-e574-11e7-8a11-b507503e622c.png)

This is because the GIF is using `http` vs `https` and creates a "mixed-content" error, at least in Chrome.

Using https fixes it.