### PR TITLE
Fixes #36 - add support for 2 GHE instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ http://repository-sync.someserver.com/sync?dest_repo=ourorg/private&destination_
 
 Don't forget to fill out the **Secret** field with your secret token!
 
+### Between a GitHub Enterprise repository and a GitHub Enterprise repository on different instances
+
+To synchronize GitHub Enterprise repositories across different GitHub Enterprise instances,
+follow the [previous guide](#between-a-github-enterprise-repository-and-a-github-enterprise-repository)
+but configure the machine token like this:
+
+| Option | Description
+| :----- | :----------
+| `GHE1HOSTNAME_MACHINE_USER_TOKEN` | **Required**.  This is [the access token the server will act as](https://help.github.com/articles/creating-an-access-token-for-command-line-use) when syncing between the repositories, generated on the first GitHub Enterprise instance. In the variable name, replace `GHE1HOSTNAME` by the hostname of the **first** Github Enterprise instance (eg `GITHUB1.MYCOMPANY.COM`).
+| `GHE2HOSTNAME_MACHINE_USER_TOKEN`  | **Required**. A second access token, generated on the second GitHub Enterprise instance. In the variable name, replace `GHE2HOSTNAME` by the hostname of the **second** Github Enterprise instance (eg `GITHUB2.MYCOMPANY.COM`).
+
+In that case, `GHE_MACHINE_USER_TOKEN` variable is not used.
+
 ## Customizing messaging
 
 Believe it or not, there are a few more environment variables you can set! These determine the text used by repository-sync when creating commit messages and pull requests. They are also dependent on the name of the destination repository. All of these values are optional.

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -69,7 +69,7 @@ class Cloner
   def originating_token
     ghe_token_env_var ||= "#{originating_hostname}_MACHINE_USER_TOKEN".upcase
     ghe_token_found = ENV["#{ghe_token_env_var}"] || ghe_token
-    @originating_token ||= (github_dotcom_dest? ? dotcom_token : ghe_token_found)
+    @originating_token ||= (github_dotcom_origin? ? dotcom_token : ghe_token_found)
   end
 
   def destination_token

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -67,11 +67,15 @@ class Cloner
   end
 
   def originating_token
-    @originating_token ||= (github_dotcom_origin? ? dotcom_token : ghe_token)
+    ghe_token_env_var ||= "#{originating_hostname}_MACHINE_USER_TOKEN".upcase
+    ghe_token_found = ENV["#{ghe_token_env_var}"] || ghe_token
+    @originating_token ||= (github_dotcom_dest? ? dotcom_token : ghe_token_found)
   end
 
   def destination_token
-    @destination_token ||= (github_dotcom_dest? ? dotcom_token : ghe_token)
+    ghe_token_env_var ||= "#{destination_hostname}_MACHINE_USER_TOKEN".upcase
+    ghe_token_found = ENV["#{ghe_token_env_var}"] || ghe_token
+    @destination_token ||= (github_dotcom_dest? ? dotcom_token : ghe_token_found)
   end
 
   def dotcom_token


### PR DESCRIPTION
This pull request adds support for GitHub repositories which are located on different GitHub Enterprise instances (GHE1, GHE2).
It preserves previous behaviour. A token specific to the GitHub host will only be used if the corresponding token environment variable is set.