### PR TITLE
Add support for Docker to host repository-sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.2.4
+MAINTAINER @ojacques
+
+RUN gem install bundler rake
+
+ENV app /app
+RUN git clone https://github.com/gjtorikian/repository-sync.git $app
+WORKDIR $app
+ADD . $app
+
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ repository-sync is a tool designed to keep two repositories—one private, one p
 
 ### Deploy
 
-First, deploy this code to Heroku
-Alternatively, use docker-compose (the app will listen on port `4567`):
+First, deploy this code to Heroku. Alternatively, use `docker-compose` (the app will listen on port `4567`):
 
 ```bash
 docker-compose build

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ docker-compose build
 docker-compose up
 ```
 
-docker-compose expects a `.env` file with environment variables properly configured as below.
+docker-compose expects a `.env` with environment variables properly configured. See the environment variables available defined below. For example:
 
 Example:
 ```
-GITHUB.ACME.COM_MACHINE_USER_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-GITHUB2.ACME.COM_MACHINE_USER_TOKEN=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+GITHUB.COM_MACHINE_USER_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+GITHUB.ACME.COM_MACHINE_USER_TOKEN=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 LANG=en_US.UTF-8
 MACHINE_USER_EMAIL=my.email@acme.com
 MACHINE_USER_NAME="GitHub Sync"

--- a/README.md
+++ b/README.md
@@ -7,9 +7,31 @@ repository-sync is a tool designed to keep two repositories—one private, one p
 
 ## Setup
 
-### Between two GitHub.com repositories
+### Deploy
 
-First, deploy this code to Heroku (or some other server you own).
+First, deploy this code to Heroku
+Alternatively, use docker-compose (the app will listen on port `4567`):
+
+```bash
+docker-compose build
+docker-compose up
+```
+
+docker-compose expects a `.env` file with environment variables properly configured as below.
+
+Example:
+```
+GITHUB.ACME.COM_MACHINE_USER_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+GITHUB2.ACME.COM_MACHINE_USER_TOKEN=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+LANG=en_US.UTF-8
+MACHINE_USER_EMAIL=my.email@acme.com
+MACHINE_USER_NAME="GitHub Sync"
+RACK_ENV=production
+REDISTOGO_URL=redis://redis:6379/
+SECRET_TOKEN=cccccccccccccccccccccccccccccccccccccccc
+```
+
+### Between two GitHub.com repositories
 
 Next, you'll need to set a few environment variables:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+web:
+  build: .
+  command: bundle exec unicorn -p 4567 -c ./unicorn.rb
+  env_file:
+     - .env
+  ports:
+    - "4567:4567"
+  links:
+    - redis
+
+worker:
+  build: .
+  command: env TERM_CHILD=1 QUEUES=* bundle exec rake jobs:work
+  env_file:
+     - .env
+  links:
+     - redis
+
+redis:
+  image: redis
+  hostname: redis
+  ports:
+    - "6379:6379"
+  restart: always


### PR DESCRIPTION
Provides an alternative to `Heroku` to host `repository-sync` with the use of `Docker`/ `docker-compose`