### PR TITLE
Add .env.template for Docker-compose case

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,7 @@
+DOTCOM_MACHINE_USER_TOKEN=<github.com personal access token>
+LANG=en_US.UTF-8
+MACHINE_USER_EMAIL=<GitHub user email>
+MACHINE_USER_NAME="GitHub Sync"
+RACK_ENV=production
+REDISTOGO_URL=redis://localhost:6379/
+SECRET_TOKEN=<secret token to be used as part of the GitHub web hook>


### PR DESCRIPTION
`docker-compose` requires an .env file to setup the environment variables. 
This pull request adds a `.env.template` which can be renamed as `.env`.